### PR TITLE
Fix example for large response

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1136,7 +1136,10 @@ mod tests {
         .unwrap();
         let split: Vec<&str> = ret.split("\n").collect();
 
-        assert_eq!(split[0], "global_hit_count{service = \"my_cool_service\", path = \"wrapper/biz/bizle\"} 0");
+        assert_eq!(
+            split[0],
+            "global_hit_count{service = \"my_cool_service\", path = \"wrapper/biz/bizle\"} 0"
+        );
         assert!(split.contains(&"global_response_time_samples{service = \"my_cool_service\", path = \"wrapper/biz/bizle\"} 0"));
     }
 }


### PR DESCRIPTION
Read data before writing any data, otherwise the connection may be
terminated before all data is actually written. This happens when the
resopnse body is bigger than ~65kb.

Although in this example the read data is thrown away, it must be read
to avoid issues.